### PR TITLE
Added length limit to the fields in registration

### DIFF
--- a/frontend/src/screens/RegistrationPage.tsx
+++ b/frontend/src/screens/RegistrationPage.tsx
@@ -15,12 +15,13 @@ const RegistrationPage = () => {
     const [firstName, setFirstName] = useState<string>("");
     const [lastName, setLastName] = useState<string>("");
     const [email, setEmail] = useState<string>("");
-    const [flexCard, setFlexCard] = useState<number | undefined>();
+    const [flexCard, setFlexCard] = useState<number | null>(null);
     const [password1, setPassword1] = useState<string>("");
     const [password2, setPassword2] = useState<string>("");
     const [isEmailValid, setIsEmailValid] = useState<boolean>(true);
     const [passwordIsValid, setPasswordIsValid] = useState<boolean>(true);
     const [isValidAccount, setIsValidAccount] = useState<boolean>(false);
+    const [isFlexCardValid, setIsFlexCardValid] = useState<boolean>(true); // true cause it can be null
 
     const [showPassword1, setShowPassword1] = useState<boolean>(false);
     const [showPassword2, setShowPassword2] = useState<boolean>(false);
@@ -49,10 +50,22 @@ const RegistrationPage = () => {
         }
     }
 
+    const handleAndValidateFlexCard = (event: ChangeEvent<HTMLInputElement>) => {
+        const flexCardInput = event.target.value;
+        const inputLength = String(flexCardInput).length
+
+        if (inputLength > 0 && inputLength !== 9) {
+            setIsFlexCardValid(false);
+        } else {
+            setIsFlexCardValid(true);
+        }
+        setFlexCard(parseInt(flexCardInput));
+    }
+
     const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
         event.preventDefault();
 
-        setIsValidAccount(isEmailValid && passwordIsValid);
+        setIsValidAccount(isEmailValid && passwordIsValid && isFlexCardValid);
 
         if (isEmailValid && passwordIsValid) {
             console.log("Creating account in DB...")
@@ -102,6 +115,7 @@ const RegistrationPage = () => {
                         type="text"
                         placeholder="John"
                         value={firstName}
+                        maxLength={255}
                         onChange={(event) => setFirstName(event.target.value)}
                     />
                 </Form.Group>
@@ -113,6 +127,7 @@ const RegistrationPage = () => {
                         type="text"
                         placeholder="Doe"
                         value={lastName}
+                        maxLength={255}
                         onChange={(event) => setLastName(event.target.value)}
                     />
                 </Form.Group>
@@ -124,6 +139,7 @@ const RegistrationPage = () => {
                         type="email"
                         placeholder="example@gmail.com"
                         value={email}
+                        maxLength={255}
                         onChange={handleAndValidateEmail}
                     />
                     {!isEmailValid && <small className="text-danger">Please enter a valid email address.</small>}
@@ -135,8 +151,9 @@ const RegistrationPage = () => {
                         type="number"
                         placeholder="300193369"
                         value={flexCard || ""}
-                        onChange={(event) => setFlexCard(parseInt(event.target.value))}
+                        onChange={handleAndValidateFlexCard}
                     />
+                    {!isFlexCardValid && <small className="text-danger">Flex card number should be 9 digits.</small>}
                 </Form.Group>
                 <Form.Group className="mt-2 mb-4">
                     <Form.Label>Password <span className="text-danger">*</span></Form.Label>
@@ -147,6 +164,8 @@ const RegistrationPage = () => {
                             type={showPassword1 ? "text" : "password"}
                             placeholder="Enter password"
                             value={password1}
+                            minLength={6}
+                            maxLength={255}
                             onChange={handleAndValidatePassword}
                         />
                         <Button
@@ -168,6 +187,8 @@ const RegistrationPage = () => {
                             type={showPassword2 ? "text" : "password"}
                             placeholder="Enter password"
                             value={password2}
+                            minLength={6}
+                            maxLength={255}
                             onChange={handleAndValidatePassword}
                         />
                         <Button


### PR DESCRIPTION
Added the following:
- Fields should not accept strings longer than 255 chars
- minimum length of 6 char for Password
- flex card should be 9 digits

Also fixed the issue when trying to create an account with no flex card number
![Screenshot 2023-07-13 at 20 31 52](https://github.com/kienmarkdo/uOBites/assets/71091659/b25f1549-5647-43b3-aef5-8a71c7e62bca)


closes #9 